### PR TITLE
Add ProgramParser for alignment

### DIFF
--- a/app/src/main/java/com/pileproject/drive/algorithm/ProgramSyntaxTree.java
+++ b/app/src/main/java/com/pileproject/drive/algorithm/ProgramSyntaxTree.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2011-2016 PILE Project, Inc. <dev@pileproject.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pileproject.drive.algorithm;
+
+import android.content.res.Resources;
+
+import java.util.ArrayList;
+
+public class ProgramSyntaxTree extends SyntaxTreeBase {
+    private static final int LEFT_PADDING_DP = 50;
+    private static final int TOP_PADDING_DP = 50;
+    protected static final int BLOCK_MARGIN_DP = 30;
+
+    public ArrayList<SyntaxTreeBase> body;
+
+    public ProgramSyntaxTree() {
+        body = new ArrayList<>();
+    }
+
+    public void addStatement(SyntaxTreeBase s) {
+        body.add(s);
+    }
+
+    @Override
+    protected int align(Resources res, int top, int left, int margin) {
+        for (SyntaxTreeBase node : body) {
+            top = node.align(res, top, left, margin);
+        }
+        return top;
+    }
+
+    public void alignment(Resources res, float dpfactor) {
+        int toppx = (int) (TOP_PADDING_DP * dpfactor + 0.5f);
+        int leftpx = (int) (LEFT_PADDING_DP * dpfactor + 0.5f);
+        int marginpx = (int) (BLOCK_MARGIN_DP * dpfactor + 0.5f);
+        this.align(res, toppx, leftpx, marginpx);
+    }
+
+    public static String bodyToString(ArrayList<SyntaxTreeBase> body) {
+        String code = "";
+        for (SyntaxTreeBase stmt : body) {
+            Class<?> c = stmt.getClass();
+            if (c == SequenceSyntaxTree.class) {
+                code += "sequence " + ((SequenceSyntaxTree) stmt).getDefinition().getClass().getSimpleName() + "\n";
+            } else if (c == RepetitionSyntaxTree.class) {
+                int numrep = ((RepetitionSyntaxTree) stmt).getRepetitionNum();
+                if (numrep == -1) {
+                    code += "repetition forever {\n";
+                } else {
+                    code += "repetition " + numrep + " times {\n";
+                }
+                code += bodyToString(((RepetitionSyntaxTree) stmt).body);
+                code += "}\n";
+            } else if (c == SelectionSyntaxTree.class) {
+                code += "selection:\ntrue {\n";
+                code += bodyToString(((SelectionSyntaxTree) stmt).truebody);
+                code += "} false {\n";
+                code += bodyToString(((SelectionSyntaxTree) stmt).falsebody);
+                code += "}\n";
+            } else {
+                code += "no such class\n";
+            }
+        }
+        return code;
+    }
+
+    public String toString() {
+        return bodyToString(body);
+    }
+}

--- a/app/src/main/java/com/pileproject/drive/algorithm/RepetitionSyntaxTree.java
+++ b/app/src/main/java/com/pileproject/drive/algorithm/RepetitionSyntaxTree.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2011-2016 PILE Project, Inc. <dev@pileproject.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pileproject.drive.algorithm;
+
+import android.content.res.Resources;
+
+import com.pileproject.drive.R;
+import com.pileproject.drive.programming.visual.block.BlockBase;
+import com.pileproject.drive.programming.visual.block.repetition.RepetitionHasNumText;
+
+import java.util.ArrayList;
+
+
+public class RepetitionSyntaxTree extends SyntaxTreeBase {
+    public ArrayList<SyntaxTreeBase> body;
+    private BlockBase mBeginblock;
+    private BlockBase mEndblock;
+    private int mNumRepetition;
+
+    public RepetitionSyntaxTree(BlockBase begin, BlockBase end, ArrayList<SyntaxTreeBase> statement) {
+        mBeginblock = begin;
+        mEndblock = end;
+        body = statement;
+
+        if (mBeginblock instanceof RepetitionHasNumText) {
+            mNumRepetition = ((RepetitionHasNumText) mBeginblock).getNum();
+        }
+    }
+
+    public int getRepetitionNum() {
+        return mNumRepetition;
+    }
+
+    @Override
+    protected int align(Resources res, int top, int left, int margin) {
+        int repblock_heightpx = res.getDimensionPixelSize(R.dimen.block_repetition_height);
+
+        // TODO(tatsuya): are these necessary?
+        mBeginblock.setLeft(left);
+        mBeginblock.setTop(top);
+
+        mBeginblock.layout(mBeginblock.getLeft(),
+                           mBeginblock.getTop(),
+                           mBeginblock.getLeft() + mBeginblock.getWidth(),
+                           mBeginblock.getTop() + mBeginblock.getHeight());
+
+        top += repblock_heightpx + margin;
+
+        for (SyntaxTreeBase node : body) {
+            top = node.align(res, top, left, margin);
+        }
+
+        // TODO(tatsuya): are these necessary?
+        mEndblock.setLeft(left);
+        mEndblock.setTop(top);
+
+        mEndblock.layout(mEndblock.getLeft(),
+                         mEndblock.getTop(),
+                         mEndblock.getLeft() + mEndblock.getWidth(),
+                         mEndblock.getTop() + mEndblock.getHeight());
+
+        top += repblock_heightpx + margin;
+        return top;
+    }
+}

--- a/app/src/main/java/com/pileproject/drive/algorithm/SelectionSyntaxTree.java
+++ b/app/src/main/java/com/pileproject/drive/algorithm/SelectionSyntaxTree.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2011-2016 PILE Project, Inc. <dev@pileproject.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pileproject.drive.algorithm;
+
+import android.content.res.Resources;
+
+import com.pileproject.drive.R;
+import com.pileproject.drive.programming.visual.block.BlockBase;
+
+import java.util.ArrayList;
+
+public class SelectionSyntaxTree extends SyntaxTreeBase {
+    public ArrayList<SyntaxTreeBase> truebody;
+    public ArrayList<SyntaxTreeBase> falsebody;
+    private BlockBase mBeginblock;
+    private BlockBase mEndblock;
+
+    public SelectionSyntaxTree(
+            BlockBase begin,
+            BlockBase end,
+            ArrayList<SyntaxTreeBase> truestatement,
+            ArrayList<SyntaxTreeBase> falsestatement) {
+        mBeginblock = begin;
+        mEndblock = end;
+        truebody = truestatement;
+        falsebody = falsestatement;
+    }
+
+    @Override
+    protected int align(Resources res, int top, int left, int margin) {
+        int beginblock_heightpx = res.getDimensionPixelSize(R.dimen.block_selection_height);
+        int beginblock_widthpx = res.getDimensionPixelSize(R.dimen.block_selection_width);
+
+        // TODO(tatsuya): are these necessary?
+        mBeginblock.setLeft(left);
+        mBeginblock.setTop(top);
+
+        mBeginblock.layout(mBeginblock.getLeft(),
+                           mBeginblock.getTop(),
+                           mBeginblock.getLeft() + mBeginblock.getWidth(),
+                           mBeginblock.getTop() + mBeginblock.getHeight());
+
+        int toppx_true = top + margin;
+        int leftpx_true = left + beginblock_widthpx + margin;
+        for (SyntaxTreeBase node : truebody) {
+            toppx_true = node.align(res, toppx_true, leftpx_true, margin);
+        }
+
+        int toppx_false = top + beginblock_heightpx + margin;
+        for (SyntaxTreeBase node : falsebody) {
+            toppx_false = node.align(res, toppx_false, left, margin);
+        }
+
+        top = Math.max(toppx_true, toppx_false);
+        int endblock_heightpx = res.getDimensionPixelSize(R.dimen.block_selection_end_height);
+
+        // TODO(tatsuya): are these necessary?
+        mEndblock.setLeft(left);
+        mEndblock.setTop(top);
+
+        mEndblock.layout(mEndblock.getLeft(),
+                         mEndblock.getTop(),
+                         mEndblock.getLeft() + mEndblock.getWidth(),
+                         mEndblock.getTop() + mEndblock.getHeight());
+
+        top += endblock_heightpx + margin;
+        return top;
+    }
+
+}

--- a/app/src/main/java/com/pileproject/drive/algorithm/SequenceSyntaxTree.java
+++ b/app/src/main/java/com/pileproject/drive/algorithm/SequenceSyntaxTree.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2011-2016 PILE Project, Inc. <dev@pileproject.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pileproject.drive.algorithm;
+
+import android.content.res.Resources;
+
+import com.pileproject.drive.R;
+import com.pileproject.drive.programming.visual.block.BlockBase;
+import com.pileproject.drive.programming.visual.block.repetition.RepetitionBreakBlock;
+
+
+public class SequenceSyntaxTree extends SyntaxTreeBase {
+    private BlockBase mDefblock;
+
+    public BlockBase getDefinition() {
+        return mDefblock;
+    }
+
+    public SequenceSyntaxTree(BlockBase define) {
+        mDefblock = define;
+    }
+
+    @Override
+    protected int align(Resources res, int top, int left, int margin) {
+        int height;
+
+        if (mDefblock.getKind() == RepetitionBreakBlock.class) {
+            height = res.getDimensionPixelSize(R.dimen.block_repetition_break_height);
+        } else {
+            height = res.getDimensionPixelSize(R.dimen.block_sequence_height);
+        }
+
+        // TODO(tatsuya): are these necessary?
+        mDefblock.setLeft(left);
+        mDefblock.setTop(top);
+
+        mDefblock.layout(mDefblock.getLeft(),
+                         mDefblock.getTop(),
+                         mDefblock.getLeft() + mDefblock.getWidth(),
+                         mDefblock.getTop() + mDefblock.getHeight());
+
+        return top + height + margin;
+    }
+}

--- a/app/src/main/java/com/pileproject/drive/algorithm/SyntaxErrorException.java
+++ b/app/src/main/java/com/pileproject/drive/algorithm/SyntaxErrorException.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2011-2016 PILE Project, Inc. <dev@pileproject.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pileproject.drive.algorithm;
+
+import com.pileproject.drive.programming.visual.block.BlockBase;
+
+@SuppressWarnings("serial")
+public class SyntaxErrorException extends Exception {
+    private BlockBase mErrorblock;
+    private ErrorCode mErrorcode;
+
+    public enum ErrorCode {
+        NESTED_IF,
+        END_BEFORE_BEGIN_FOR,
+        END_BEFORE_BEGIN_IF,
+        UNEXPECTED_BREAK,
+        NO_END_FOR,
+        NO_END_IF,
+        OTHER  // TODO: find other reasons for syntax errors
+    }
+
+    public SyntaxErrorException(BlockBase error, ErrorCode code) {
+        mErrorblock = error;
+        mErrorcode = code;
+    }
+
+    public BlockBase getBlock() {
+        return mErrorblock;
+    }
+
+    public ErrorCode getErrorCode() {
+        return mErrorcode;
+    }
+}

--- a/app/src/main/java/com/pileproject/drive/algorithm/SyntaxParser.java
+++ b/app/src/main/java/com/pileproject/drive/algorithm/SyntaxParser.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2011-2016 PILE Project, Inc. <dev@pileproject.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pileproject.drive.algorithm;
+
+import com.pileproject.drive.programming.visual.activity.BlockPositionComparator;
+import com.pileproject.drive.programming.visual.block.BlockBase;
+import com.pileproject.drive.programming.visual.block.repetition.RepetitionBlock;
+import com.pileproject.drive.programming.visual.block.repetition.RepetitionBreakBlock;
+import com.pileproject.drive.programming.visual.block.repetition.RepetitionEndBlock;
+import com.pileproject.drive.programming.visual.block.selection.SelectionBlock;
+import com.pileproject.drive.programming.visual.block.selection.SelectionEndBlock;
+import com.pileproject.drive.programming.visual.block.sequence.SequenceBlock;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static com.pileproject.drive.algorithm.SyntaxErrorException.ErrorCode;
+
+public class SyntaxParser {
+    public static ProgramSyntaxTree parseProgram(ArrayList<BlockBase> blocks) throws SyntaxErrorException {
+        ProgramSyntaxTree program = new ProgramSyntaxTree();
+
+        Collections.sort(blocks, new BlockPositionComparator());
+        Iterator<BlockBase> it = blocks.iterator();
+        while (it.hasNext()) {
+            program.addStatement(parseStatement(it));
+        }
+        return program;
+    }
+
+    private static SyntaxTreeBase parseStatement(Iterator<BlockBase> blockiter) throws SyntaxErrorException {
+        BlockBase curblock = blockiter.next();
+        Class<? extends BlockBase> c = curblock.getKind();
+        if (c == SequenceBlock.class) {
+            return new SequenceSyntaxTree(curblock);
+        } else if (c == RepetitionBlock.class) {
+            return parseRepetition(blockiter, curblock);
+        } else if (c == SelectionBlock.class) {
+            return parseSelection(blockiter, curblock, false);
+        } else {
+            ErrorCode code;
+            if (c == RepetitionBreakBlock.class) {
+                code = ErrorCode.UNEXPECTED_BREAK;
+            } else if (c == RepetitionEndBlock.class) {
+                code = ErrorCode.END_BEFORE_BEGIN_FOR;
+            } else if (c == SelectionEndBlock.class) {
+                code = ErrorCode.END_BEFORE_BEGIN_IF;
+            } else {
+                code = ErrorCode.OTHER;
+            }
+            throw new SyntaxErrorException(curblock, code);
+        }
+    }
+
+    private static RepetitionSyntaxTree parseRepetition(Iterator<BlockBase> blockiter, BlockBase defblock)
+            throws SyntaxErrorException {
+        ArrayList<SyntaxTreeBase> body = new ArrayList<>();
+        try {
+            BlockBase curblock = blockiter.next();
+            while (!(curblock instanceof RepetitionEndBlock)) {
+                Class<? extends BlockBase> c = curblock.getKind();
+                if (c == SequenceBlock.class) {
+                    body.add(new SequenceSyntaxTree(curblock));
+                } else if (c == RepetitionBlock.class) {
+                    body.add(parseRepetition(blockiter, curblock));
+                } else if (c == RepetitionBreakBlock.class) {
+                    body.add(new SequenceSyntaxTree(curblock));
+                } else if (c == SelectionBlock.class) {
+                    body.add(parseSelection(blockiter, curblock, true));
+                } else {
+                    ErrorCode code;
+                    if (c == SelectionEndBlock.class) {
+                        code = ErrorCode.END_BEFORE_BEGIN_IF;
+                    } else {
+                        code = ErrorCode.OTHER;
+                    }
+                    throw new SyntaxErrorException(curblock, code);
+                }
+                curblock = blockiter.next();
+            }
+            // now curblock points RepetitionEndBlock
+            return new RepetitionSyntaxTree(defblock, curblock, body);
+        } catch (NoSuchElementException noex) {
+            throw new SyntaxErrorException(defblock, ErrorCode.NO_END_FOR);
+        }
+    }
+
+    private static SelectionSyntaxTree parseSelection(
+            Iterator<BlockBase> blockiter,
+            BlockBase defblock,
+            boolean inwhile) throws SyntaxErrorException {
+        ArrayList<SyntaxTreeBase> truebody;
+        ArrayList<SyntaxTreeBase> falsebody;
+        ArrayList<BlockBase> truebodyBlocks = new ArrayList<>();
+        ArrayList<BlockBase> falsebodyBlocks = new ArrayList<>();
+
+        int threshold = defblock.getRight();
+        try {
+            BlockBase curblock = blockiter.next();
+            while (!(curblock instanceof SelectionEndBlock)) {
+                if (curblock.getLeft() > threshold) {
+                    truebodyBlocks.add(curblock);
+                } else {
+                    falsebodyBlocks.add(curblock);
+                }
+                curblock = blockiter.next();
+            }
+            // now curblock points SelectionEndBlock
+            truebody = parseSelectionBody(truebodyBlocks, inwhile);
+            falsebody = parseSelectionBody(falsebodyBlocks, inwhile);
+            return new SelectionSyntaxTree(defblock, curblock, truebody, falsebody);
+        } catch (NoSuchElementException noex) {
+            throw new SyntaxErrorException(defblock, ErrorCode.NO_END_IF);
+        }
+    }
+
+    private static ArrayList<SyntaxTreeBase> parseSelectionBody(ArrayList<BlockBase> blocks, boolean inwhile)
+            throws SyntaxErrorException {
+        ArrayList<SyntaxTreeBase> body = new ArrayList<>();
+        Iterator<BlockBase> it = blocks.iterator();
+        while (it.hasNext()) {
+            BlockBase curblock = it.next();
+            Class<? extends BlockBase> c = curblock.getKind();
+            if (c == SequenceBlock.class) {
+                body.add(new SequenceSyntaxTree(curblock));
+            } else if (c == RepetitionBlock.class) {
+                body.add(parseRepetition(it, curblock));
+            } else if (c == RepetitionBreakBlock.class && inwhile == true) {
+                body.add(new SequenceSyntaxTree(curblock));
+            } else {
+                ErrorCode code;
+                if (c == RepetitionBreakBlock.class) {
+                    code = ErrorCode.UNEXPECTED_BREAK;
+                } else if (c == RepetitionEndBlock.class) {
+                    code = ErrorCode.END_BEFORE_BEGIN_FOR;
+                } else if (c == SelectionBlock.class) {
+                    code = ErrorCode.NESTED_IF;
+                } else {
+                    code = ErrorCode.OTHER;
+                }
+                throw new SyntaxErrorException(curblock, code);
+            }
+        }
+        return body;
+    }
+}

--- a/app/src/main/java/com/pileproject/drive/algorithm/SyntaxTreeBase.java
+++ b/app/src/main/java/com/pileproject/drive/algorithm/SyntaxTreeBase.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2011-2016 PILE Project, Inc. <dev@pileproject.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pileproject.drive.algorithm;
+
+import android.content.res.Resources;
+
+public abstract class SyntaxTreeBase {
+    protected abstract int align(Resources res, int top, int left, int margin);
+}


### PR DESCRIPTION
# Parsing blocks feature

This is an experimental PR that introduces a parsing feature to our apps. These codes were originally written by Yuya Ono ( @onoyuuya ) .
# How to use

This is a simple snippet that shows how to use this parser.

```
       SyntaxParser mProgramTree;

       private void alignBlocks() {
               parseBlocks();
               float dpfactor = getResources().getDisplayMetrics().density;
               Resources res = getResources();
               mProgramTree.alignment(res, dpfactor);
       }

       private void parseBlocks() {
               ArrayList<BaseBlock> blocks;
               blocks = load...;

               try {
                       mProgramTree = SyntaxParser.parseProgram(blocks);
                       new AlertDialog.Builder(this)
                               .setTitle("Analyze Result")
                               .setMessage(mProgramTree.toString())
                               .setPositiveButton(R.string.ok, null)
                               .show();
               } catch (SyntaxErrorException synex) {
                       new AlertDialog.Builder(this)
                               .setTitle("Syntax Error")
                               .setMessage(
                                       String.format("%s\nat %s", synex.getErrorCode(), synex.getBlock()))
                               .setPositiveButton(R.string.ok, null)
                               .show();
                       return;
               }
       }
```
# Status

I have just imported the original codes and fixed them a little to remove errors. The modification I made may cause bugs (I'm not sure). I will check and refactor them.
# Discussion

These codes originally have been made for alignment but we want to make it forward - convert blocks into codes. How should we do for the purpose? 
