### PR TITLE
Upgrade SquiDB from 2.0.2 to 3.1.3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,6 +67,8 @@ android {
     }
 }
 
+def squidbVersion = '3.1.3'
+
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
 
@@ -95,9 +97,10 @@ dependencies {
     compile 'com.android.support:preference-v7:23.0.1'
 
     // libraries for database
-    apt 'com.yahoo.squidb:squidb-processor:2.0.2'
-    compile 'com.yahoo.squidb:squidb:2.0.2'
-    compile 'com.yahoo.squidb:squidb-annotations:2.0.2'
+    compile "com.yahoo.squidb:squidb:$squidbVersion"
+    compile "com.yahoo.squidb:squidb-annotations:$squidbVersion"
+    compile "com.yahoo.squidb:squidb-android:$squidbVersion"
+    apt "com.yahoo.squidb:squidb-processor:$squidbVersion"
 
     // library for preference
     apt 'com.rejasupotaro:kvs-schema-compiler:5.0.0'

--- a/app/src/main/java/com/pileproject/drive/database/DriveDatabase.java
+++ b/app/src/main/java/com/pileproject/drive/database/DriveDatabase.java
@@ -18,8 +18,10 @@ package com.pileproject.drive.database;
 
 import android.content.Context;
 
+import com.yahoo.squidb.android.AndroidOpenHelper;
+import com.yahoo.squidb.data.ISQLiteDatabase;
+import com.yahoo.squidb.data.ISQLiteOpenHelper;
 import com.yahoo.squidb.data.SquidDatabase;
-import com.yahoo.squidb.data.adapter.SQLiteDatabaseWrapper;
 import com.yahoo.squidb.sql.Table;
 
 /**
@@ -31,9 +33,11 @@ import com.yahoo.squidb.sql.Table;
 public class DriveDatabase extends SquidDatabase {
     private static final int VERSION = 1;
     private static final String NAME = "drive.db";
+    private final Context mContext;
 
     public DriveDatabase(Context context) {
-        super(context);
+        super();
+        mContext = context;
     }
 
     @Override
@@ -55,7 +59,12 @@ public class DriveDatabase extends SquidDatabase {
     }
 
     @Override
-    protected boolean onUpgrade(SQLiteDatabaseWrapper db, int oldVersion, int newVersion) {
+    protected boolean onUpgrade(ISQLiteDatabase db, int oldVersion, int newVersion) {
         return false;
+    }
+
+    @Override
+    protected ISQLiteOpenHelper createOpenHelper(String databaseName, OpenHelperDelegate delegate, int version) {
+        return new AndroidOpenHelper(mContext, databaseName, delegate, version);
     }
 }

--- a/app/src/main/java/com/pileproject/drive/database/ProgramDataSpec.java
+++ b/app/src/main/java/com/pileproject/drive/database/ProgramDataSpec.java
@@ -17,6 +17,7 @@
 package com.pileproject.drive.database;
 
 import com.yahoo.squidb.annotations.ColumnSpec;
+import com.yahoo.squidb.annotations.PrimaryKey;
 import com.yahoo.squidb.annotations.TableModelSpec;
 
 /**
@@ -28,7 +29,9 @@ import com.yahoo.squidb.annotations.TableModelSpec;
 @TableModelSpec(className="ProgramData", tableName="program_data",
                 tableConstraint = "FOREIGN KEY(programId) references programs(_id) ON DELETE CASCADE")
 public class ProgramDataSpec {
-    // _id will be generated automatically
+    @PrimaryKey
+    @ColumnSpec(name = "_id")
+    long id;
 
     @ColumnSpec(constraints = "NOT NULL")
     long programId;

--- a/app/src/main/java/com/pileproject/drive/database/ProgramSpec.java
+++ b/app/src/main/java/com/pileproject/drive/database/ProgramSpec.java
@@ -18,6 +18,7 @@ package com.pileproject.drive.database;
 
 import com.yahoo.squidb.annotations.ColumnSpec;
 import com.yahoo.squidb.annotations.Constants;
+import com.yahoo.squidb.annotations.PrimaryKey;
 import com.yahoo.squidb.annotations.TableModelSpec;
 
 /**
@@ -28,7 +29,9 @@ import com.yahoo.squidb.annotations.TableModelSpec;
  */
 @TableModelSpec(className="Program", tableName="programs")
 public class ProgramSpec {
-    // _id will be generated automatically
+    @PrimaryKey
+    @ColumnSpec(name = "_id")
+    long id;
 
     // the name of a program
     @ColumnSpec(constraints = "NOT NULL")


### PR DESCRIPTION
I upgrade SquiDB. Most of the changes are based on some class name changes.
### Note: `_id` generation and warnings

SquiDB is in a transitional period as for `_id` column which is automatically generated by default but it will be disabled in the future and now it produces `getId() is deprecated` warnings after 3.1.0 even if follows their instruction (So, please ignore these warnings).

For more detail, please see: [Primary keys · yahoo/squidb Wiki](https://goo.gl/xXK9er)
