### PR TITLE
Apply the license format to tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -130,5 +130,4 @@ dependencies {
 license {
     header rootProject.file('LICENSE')
     includes(["**/*.java", "**/*.xml"])
-    exclude "**/*Test.java"
 }

--- a/app/src/androidTest/java/com/pileproject/drive/ApplicationTest.java
+++ b/app/src/androidTest/java/com/pileproject/drive/ApplicationTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 PILE Project, Inc. <dev@pileproject.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.pileproject.drive;
 
 import android.app.Application;

--- a/app/src/androidTest/java/com/pileproject/drive/comm/BluetoothCommunicatorTest.java
+++ b/app/src/androidTest/java/com/pileproject/drive/comm/BluetoothCommunicatorTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 PILE Project, Inc. <dev@pileproject.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.pileproject.drive.comm;
 
 import android.support.test.runner.AndroidJUnit4;

--- a/app/src/androidTest/java/com/pileproject/drive/execution/BlockProgramLogicTest.java
+++ b/app/src/androidTest/java/com/pileproject/drive/execution/BlockProgramLogicTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 PILE Project, Inc. <dev@pileproject.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.pileproject.drive.execution;
 
 import android.support.test.runner.AndroidJUnit4;

--- a/app/src/androidTest/java/com/pileproject/drive/execution/NxtControllerTest.java
+++ b/app/src/androidTest/java/com/pileproject/drive/execution/NxtControllerTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 PILE Project, Inc. <dev@pileproject.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.pileproject.drive.execution;
 
 import android.support.test.runner.AndroidJUnit4;

--- a/app/src/androidTest/java/com/pileproject/drive/programming/visual/block/NumberTextViewDelegateTest.java
+++ b/app/src/androidTest/java/com/pileproject/drive/programming/visual/block/NumberTextViewDelegateTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 PILE Project, Inc. <dev@pileproject.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.pileproject.drive.programming.visual.block;
 
 import android.support.test.runner.AndroidJUnit4;

--- a/app/src/androidTest/java/com/pileproject/drive/util/development/UnitTest.java
+++ b/app/src/androidTest/java/com/pileproject/drive/util/development/UnitTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 PILE Project, Inc. <dev@pileproject.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.pileproject.drive.util.development;
 
 import android.content.res.Configuration;

--- a/app/src/test/java/com/pileproject/drive/util/development/MeasurementUnitTest.java
+++ b/app/src/test/java/com/pileproject/drive/util/development/MeasurementUnitTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 PILE Project, Inc. <dev@pileproject.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.pileproject.drive.util.development;
 
 import org.junit.Test;

--- a/app/src/test/java/com/pileproject/drive/util/math/RangeTest.java
+++ b/app/src/test/java/com/pileproject/drive/util/math/RangeTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 PILE Project, Inc. <dev@pileproject.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.pileproject.drive.util.math;
 
 import org.junit.Test;

--- a/app/src/test/java/com/pileproject/drive/util/string/NumberUtilTest.java
+++ b/app/src/test/java/com/pileproject/drive/util/string/NumberUtilTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 PILE Project, Inc. <dev@pileproject.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.pileproject.drive.util.string;
 
 import org.junit.Test;

--- a/app/src/test/java/com/pileproject/drive/util/string/ParseUtilTest.java
+++ b/app/src/test/java/com/pileproject/drive/util/string/ParseUtilTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2011-2015 PILE Project, Inc. <dev@pileproject.com>
+/**
+ * Copyright (C) 2011-2016 PILE Project, Inc. <dev@pileproject.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.pileproject.drive.util.string;
 
 import org.junit.Test;


### PR DESCRIPTION
Hi @myusak,

Although I mentioned `*Test.java` files failed to pass `license` task in #57, 
I checked it again and finally made them passed the check by using `licenseFormat` task. 

So, now we can force all the files (`*.java`, `*.xml`) to have the correct copyrights.