### PR TITLE
Make sudo required in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: android
 jdk: oraclejdk8
 
-sudo: false
+sudo: required
 
 env:
   global:


### PR DESCRIPTION
This PR makes `sudo` enabled in CI. 
This was suggested by a Customer Support Specialist of Travis to make CI more stable in an e-mail I received after asking why it failed randomly ( #49 ). At least, it passed in [a build](https://travis-ci.org/tiwanari/drive/builds/179670009). 

> I had a look at your build and I can see that it's running on our container-based infrastructure. Other users have reported more stable builds on our sudo-enabled infrastructure, would you like to give this a try? Here's what you need to add to your .travis.yml file:
> 
> sudo: required
> 
> One major difference is that the sudo-enabled VMs have 7.5 GB of RAM instead of 4 GB (shared) on the container-based infrastructure.
> 
> Please let us know the result and we will follow-up upon your reply.
