### PR TITLE
Fix a bug on validation for MAC address

### DIFF
--- a/app/src/ev3/java/com/pileproject/drive/preferences/MachinePreferencesSchema.java
+++ b/app/src/ev3/java/com/pileproject/drive/preferences/MachinePreferencesSchema.java
@@ -27,7 +27,7 @@ import com.rejasupotaro.android.kvs.annotations.Table;
 @Table(name = "machine_preferences")
 public class MachinePreferencesSchema {
     @Key(name = "bluetooth_address")
-    String macAddress;
+    String macAddress = "";
 
     @Key(name = "input_port_1")
     final String inputPort1 = CarControllerBase.InputDevice.TOUCH;

--- a/app/src/main/java/com/pileproject/drive/programming/visual/activity/ProgrammingActivity.java
+++ b/app/src/main/java/com/pileproject/drive/programming/visual/activity/ProgrammingActivity.java
@@ -97,7 +97,7 @@ public class ProgrammingActivity extends AppCompatActivity implements AlertDialo
         mSpaceManager.saveExecutionProgram();
 
         // TODO: remove bluetooth-dependent code for WiFiCommunicator
-        String address = MachinePreferences.get(getApplicationContext()).getMacAddress();
+        String address = MachinePreferences.get(getApplicationContext()).getMacAddress("");
 
         if (!address.equals("") || DeployUtil.isOnEmulator()) {
             Intent intent = ExecutionActivity.createIntent(getApplicationContext());
@@ -134,9 +134,10 @@ public class ProgrammingActivity extends AppCompatActivity implements AlertDialo
 
     private void setUpToolbar() {
         // get device address to show it on toolbar
-        String deviceAddress = MachinePreferences.get(getApplicationContext()).getMacAddress();
+        String deviceAddress = MachinePreferences.get(getApplicationContext()).getMacAddress("");
         deviceAddress =
-                (deviceAddress == null) ? getResources().getString(R.string.programming_noTargetDevice) : deviceAddress;
+                (deviceAddress.equals("")) ?
+                        getResources().getString(R.string.programming_noTargetDevice) : deviceAddress;
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.programming_toolbar);
         toolbar.inflateMenu(R.menu.menu_programming);

--- a/app/src/main/java/com/pileproject/drive/programming/visual/activity/ProgrammingActivity.java
+++ b/app/src/main/java/com/pileproject/drive/programming/visual/activity/ProgrammingActivity.java
@@ -99,7 +99,7 @@ public class ProgrammingActivity extends AppCompatActivity implements AlertDialo
         // TODO: remove bluetooth-dependent code for WiFiCommunicator
         String address = MachinePreferences.get(getApplicationContext()).getMacAddress();
 
-        if (address != null || DeployUtil.isOnEmulator()) {
+        if (!address.equals("") || DeployUtil.isOnEmulator()) {
             Intent intent = ExecutionActivity.createIntent(getApplicationContext());
             startActivityForResult(intent, ACTIVITY_RESULT_EXECUTE_PROGRAM);
             return ;

--- a/app/src/main/java/com/pileproject/drive/programming/visual/activity/ProgrammingActivity.java
+++ b/app/src/main/java/com/pileproject/drive/programming/visual/activity/ProgrammingActivity.java
@@ -134,10 +134,8 @@ public class ProgrammingActivity extends AppCompatActivity implements AlertDialo
 
     private void setUpToolbar() {
         // get device address to show it on toolbar
-        String deviceAddress = MachinePreferences.get(getApplicationContext()).getMacAddress("");
-        deviceAddress =
-                (deviceAddress.equals("")) ?
-                        getResources().getString(R.string.programming_noTargetDevice) : deviceAddress;
+        final String defaultString = getResources().getString(R.string.programming_noTargetDevice);
+        final String deviceAddress = MachinePreferences.get(getApplicationContext()).getMacAddress(defaultString);
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.programming_toolbar);
         toolbar.inflateMenu(R.menu.menu_programming);

--- a/app/src/nxt/java/com/pileproject/drive/preferences/MachinePreferencesSchema.java
+++ b/app/src/nxt/java/com/pileproject/drive/preferences/MachinePreferencesSchema.java
@@ -32,7 +32,7 @@ public class MachinePreferencesSchema {
     }
 
     @Key(name = "bluetooth_address")
-    String macAddress;
+    String macAddress = "";
 
     @Key(name = "firmware")
     final String firmware = Firmware.STANDARD;


### PR DESCRIPTION
I found a small but fatal bug. 

The validation of a MAC address is wrong. If the string is not set, `""` will be returned not null.